### PR TITLE
Merge custom_config with cookieconsentInitialse

### DIFF
--- a/templates/partials/init-simple-cookie.html.twig
+++ b/templates/partials/init-simple-cookie.html.twig
@@ -14,9 +14,10 @@ window.addEventListener("load", function() {
 	{# Check if we need the custom configuration. #}
 	if (pluginConfig.custom)
 	{
-		cookieconsentInitialse = JSON.parse(
+		var customInitialise = JSON.parse(
 			pluginConfig.custom_config.replace(/\r?\n|\r/g,'')
 		);
+		cookieconsentInitialse = Object.assign({}, cookieconsentInitialse, customInitialise);
 	}
 
 	{# Initialize cookie consent banner #}


### PR DESCRIPTION
It would not make sense for `custom_config` to reset the whole configuration, and it would force anyone using `custom_config` to rewrite all the configuration.

This PR simply merges the default configuration with the content of  `custom_config`